### PR TITLE
그리드 수정 및 Animation 조정

### DIFF
--- a/Assets/Script/CutScene/CutSceneController.cs
+++ b/Assets/Script/CutScene/CutSceneController.cs
@@ -13,6 +13,10 @@ public class CutSceneController : MonoBehaviour
 
     public float ZoomTime = 1;
     public float CutSceneTime = 1;
+
+    public float BlinkTime = 0.1f;
+    public float ShakePower = 1;
+    public float ShakeTime = 0.1f;
     
 
     public void BattleCutScene(BattleUnit AttackUnit, List<BattleUnit> HitUnits)
@@ -56,8 +60,12 @@ public class CutSceneController : MonoBehaviour
     {
         foreach (BattleUnit unit in CSData.HitUnits)
         {
-            if(unit != null)
+            if (unit != null)
+            {
                 unit.GetComponent<Animator>().SetBool("isHit", true);
+                StartCoroutine(UnitBlink(unit));
+                StartCoroutine(UnitShake(unit));
+            }
         }
 
         yield return StartCoroutine(AttackTilt());
@@ -138,5 +146,55 @@ public class CutSceneController : MonoBehaviour
                 unit.GetComponent<SpriteRenderer>().sortingOrder = rayer;
         }
 
+    }
+
+    private IEnumerator UnitBlink(BattleUnit unit)
+    {
+        SpriteRenderer sr = unit.GetComponent<SpriteRenderer>();
+
+        sr.color = Color.black;
+
+        yield return new WaitForSeconds(BlinkTime);
+
+        sr.color = Color.white;
+
+        yield return new WaitForSeconds(BlinkTime);
+
+        sr.color = Color.black;
+
+        yield return new WaitForSeconds(BlinkTime);
+
+        sr.color = Color.white;
+    }
+
+    private IEnumerator UnitShake(BattleUnit unit)
+    {
+        Transform trans = unit.transform;
+        Vector3 originPos = trans.position;
+        
+        float power = ShakePower;
+        float time = ShakeTime / ShakePower;
+        bool min = true;
+
+        trans.position += new Vector3(power / 2, 0, 0);
+        power -= time;
+
+        while (power > 0)
+        {
+            if (trans == null)
+                yield break;
+
+            Vector3 vec = new Vector3(power, 0, 0);
+            if (min) vec *= -1;
+
+            trans.position += vec;
+            power -= time;
+            min = !min;
+
+            yield return new WaitForSeconds(ShakeTime / ShakePower);
+            Debug.Log('a');
+        }
+
+        trans.position = originPos;
     }
 }

--- a/Assets/Script/Field/Field.cs
+++ b/Assets/Script/Field/Field.cs
@@ -14,7 +14,7 @@ public class Field : MonoBehaviour
     // 필드의 생성을 위한 필드의 위치
     private Vector3 FieldPosition => new Vector3(0, -0.35f, 0.5f);
     private Vector3 FieldRotation => new Vector3(41.5f, 0, 0);
-    private Vector3 FieldScale => new Vector3(18.54f, 9.28f, 1f);
+    private Vector3 FieldScale => new Vector3(21f, 10.7f, 1f);
 
     private const int MaxFieldX = 6;
     private const int MaxFieldY = 3;
@@ -133,6 +133,7 @@ public class Field : MonoBehaviour
         
         float sizeY = TileDict[coord].transform.lossyScale.y * 0.2f;
         position.y -= sizeY;
+        //position.z = 1.729823f;
 
         return position;
     }

--- a/Assets/Script/Field/Field.cs
+++ b/Assets/Script/Field/Field.cs
@@ -133,7 +133,6 @@ public class Field : MonoBehaviour
         
         float sizeY = TileDict[coord].transform.lossyScale.y * 0.2f;
         position.y -= sizeY;
-        //position.z = 1.729823f;
 
         return position;
     }

--- a/Assets/Script/Manager/BattleManager/BattleManager.cs
+++ b/Assets/Script/Manager/BattleManager/BattleManager.cs
@@ -292,8 +292,8 @@ public class BattleManager : MonoBehaviour
             unit.PassiveCheck(unit, hit, PassiveType.BEFOREATTACK);
             unit.SkillUse(hit);
 
-            if (unit.SkillEffect != null)
-                GameManager.VisualEffect.StartVisualEffect(unit.SkillEffect, hit.transform.position);
+            if (unit.SkillEffectAnim != null)
+                GameManager.VisualEffect.StartVisualEffect(unit.SkillEffectAnim, hit.transform.position);
             
             if (team != hit.Team)
                 hit.ChangeHP(1000);

--- a/Assets/Script/ScriptableObject/UnitDataSO.cs
+++ b/Assets/Script/ScriptableObject/UnitDataSO.cs
@@ -35,11 +35,11 @@ public class UnitDataSO : ScriptableObject
     [SerializeField] private RuntimeAnimatorController _corruptionAnimatorController;
     public RuntimeAnimatorController CorruptionAnimatorController => _corruptionAnimatorController;
 
-    [SerializeField] private AnimationClip _skillEffectController;
-    public AnimationClip SkillEffectController => _skillEffectController;
+    [SerializeField] private AnimationClip _skillEffectAnim;
+    public AnimationClip SkillEffectAnim => _skillEffectAnim;
 
-    [SerializeField] private AnimationClip _corruptionSkillEffectController;
-    public AnimationClip CorruptionSkillEffectController => _corruptionSkillEffectController;
+    [SerializeField] private AnimationClip _corruptionSkillEffectAnim;
+    public AnimationClip CorruptionSkillEffectAnim => _corruptionSkillEffectAnim;
 
     [SerializeField] private AnimType _animType;
     public AnimType AnimType => _animType;

--- a/Assets/Script/Unit/BattleUnit.cs
+++ b/Assets/Script/Unit/BattleUnit.cs
@@ -16,7 +16,7 @@ public class BattleUnit : MonoBehaviour
 
     private SpriteRenderer _renderer;
     private Animator UnitAnimator;
-    public AnimationClip SkillEffect;
+    public AnimationClip SkillEffectAnim;
 
     [SerializeField] public UnitAIController AI;
 
@@ -28,6 +28,7 @@ public class BattleUnit : MonoBehaviour
 
     [SerializeField] Vector2 _location;
     public Vector2 Location => _location;
+    private float scale;
 
     // 23.02.16 임시 수정
     private Action<BattleUnit> _UnitDeadAction;
@@ -47,6 +48,7 @@ public class BattleUnit : MonoBehaviour
         Debug.Log(Stat.CurrentHP);
         HP.Init(Stat.HP, Stat.CurrentHP);
         Fall.Init(Stat.FallCurrentCount, Stat.FallMaxCount);
+        scale = transform.localScale.x;
 
         _renderer.sprite = Data.Image;
         GameManager.Sound.Play("Summon/SummonSFX");
@@ -139,14 +141,14 @@ public class BattleUnit : MonoBehaviour
         if(Team == Team.Player)
         {
             UnitAnimator.runtimeAnimatorController = Data.CorruptionAnimatorController;
-            if (Data.CorruptionSkillEffectController != null)
-                SkillEffect = Data.CorruptionSkillEffectController;
+            if (Data.CorruptionSkillEffectAnim != null)
+                SkillEffectAnim = Data.CorruptionSkillEffectAnim;
         }
         else
         {
             UnitAnimator.runtimeAnimatorController = Data.AnimatorController;
-            if (Data.SkillEffectController != null)
-                SkillEffect = Data.SkillEffectController;
+            if (Data.SkillEffectAnim != null)
+                SkillEffectAnim = Data.SkillEffectAnim;
         }
     }
 
@@ -159,12 +161,16 @@ public class BattleUnit : MonoBehaviour
     {
         float moveTime = 0.4f;
         float time = 0;
-        Vector3 cur = transform.position;
+        Vector3 curP = transform.position;
+        Vector3 curS = transform.localScale;
+
+        float addScale = scale + ((scale * 0.1f) * (Location.y - 1));
 
         while (time < moveTime)
         {
             time += Time.deltaTime;
-            transform.position = Vector3.Lerp(cur, dest, time / moveTime);
+            transform.position = Vector3.Lerp(curP, dest, time / moveTime);
+            transform.localScale = Vector3.Lerp(curS, new Vector3(addScale, addScale, 1), time / moveTime);
             yield return null;
         }
     }

--- a/Assets/Script/Unit/BattleUnit.cs
+++ b/Assets/Script/Unit/BattleUnit.cs
@@ -28,7 +28,9 @@ public class BattleUnit : MonoBehaviour
 
     [SerializeField] Vector2 _location;
     public Vector2 Location => _location;
+
     private float scale;
+    private float GetModifiedScale() => scale + ((scale * 0.1f) * (Location.y - 1));
 
     // 23.02.16 임시 수정
     private Action<BattleUnit> _UnitDeadAction;
@@ -154,7 +156,10 @@ public class BattleUnit : MonoBehaviour
 
     public void SetPosition(Vector3 dest)
     {
+        float s = GetModifiedScale();
+
         transform.position = dest;
+        transform.localScale = new Vector3(s, s, 1);
     }
 
     public IEnumerator MovePosition(Vector3 dest)
@@ -164,7 +169,7 @@ public class BattleUnit : MonoBehaviour
         Vector3 curP = transform.position;
         Vector3 curS = transform.localScale;
 
-        float addScale = scale + ((scale * 0.1f) * (Location.y - 1));
+        float addScale = GetModifiedScale();
 
         while (time < moveTime)
         {


### PR DESCRIPTION
## 📝 PR 설명
> 이 PR에서 추가/수정하려는 내용, 이 PR이 필요한 이유, 이런 방식으로 구현한 이유, 기타 중요한 내용 등을 정리해 적어주세요.

- FieldScale을 배경화면의 타일에 맞게 조정

- BattleUnit에 기본 크기(Scale)를 저장해 둔 뒤, 화면에서 멀어질 경우 10% 더 크게,
  가까워질 경우 10% 더 작게 만듦으로써 원근감을 줄임 (GetModifiedScale)

- AnimationClip을 사용하는 변수들의 이름 수정(SkillEffectAnim, CorruptSkillEffectAnim)

- 피격 시 깜빡임, 흔들림 추가 (임시),  CutSceneManager를 통해 Hierachy에서 수정할 수 있음
  깜빡임은 스프라이트를 전달받으면 애니메이션을 통해 흰색으로 깜빡거리도록 변경될 것



## 🧪 테스트 방법
> 이 PR이 목표한 바를 잘 달성하고 있는지 확인한 방법을 알려주세요.