### PR TITLE
Enum 낙인 제거, 고유 낙인 용어 변경, 낙인 중복 제거

### DIFF
--- a/Assets/Script/ScriptableObject/UnitDataSO.cs
+++ b/Assets/Script/ScriptableObject/UnitDataSO.cs
@@ -9,8 +9,8 @@ public class UnitDataSO : ScriptableObject
     [SerializeField] private Stat _rawStat;
     public Stat RawStat => _rawStat;
 
-    [SerializeField] private List<Passive> _inherenceStigma = new List<Passive>();
-    public List<Passive> IngerenceStigma => _inherenceStigma;
+    [SerializeField] private List<Passive> _uniqueStigma = new List<Passive>();
+    public List<Passive> UniqueStigma => _uniqueStigma;
 
     // 변경되지않는 값들
 

--- a/Assets/Script/Unit/DeckUnit.cs
+++ b/Assets/Script/Unit/DeckUnit.cs
@@ -11,7 +11,6 @@ public class DeckUnit
     [SerializeField] public Stat ChangedStat; // 영구 변화 수치
     public Stat Stat => Data.RawStat + ChangedStat; // Memo : 나중에 낙인, 버프 추가한 스탯으로 수정
     
-    [SerializeField] private List<낙인> stigmas = new List<낙인>();
     [SerializeField] public List<Passive> Stigma = new List<Passive>();
 
     private int _maxStigmaCount = 3;
@@ -21,12 +20,24 @@ public class DeckUnit
         foreach (Passive stigma in Data.IngerenceStigma)
             AddStigma(stigma);
 
-        foreach (낙인 stigma in stigmas)
-            SetStigmaByEnum(stigma);
+        foreach (Passive stigma in Stigma)
+            AddStigma(stigma);
     }
 
     public void AddStigma(Passive passive)
     {
+        if (Stigma.Contains(passive))
+        {
+            Debug.Log($"이미 장착된 낙인입니다. : {passive.Name}");
+            return;
+        }
+
+        if(Stigma.Count >= _maxStigmaCount)
+        {
+            Debug.Log("최대 낙인 개수");
+            return;
+        }
+
         Stigma.Add(passive);
     }
 
@@ -42,64 +53,5 @@ public class DeckUnit
         Type removed = Stigma[num].GetType(); // 지워질 패시브의 정보
         Stigma.RemoveAt(num);
         return removed;
-    }
-
-    // 낙인 수정
-    public void SetStigmaByEnum(낙인 stigma)
-    {
-        if(Stigma.Count >= _maxStigmaCount)
-        {
-            Debug.Log($"이미 낙인이 {_maxStigmaCount}개임");
-            return;
-        }
-
-        Passive newPassive = null;
-
-        switch (stigma)
-        {
-            case 낙인.가학:
-                newPassive = new 가학();
-                break;
-            case 낙인.강림:
-                newPassive = new 강림();
-                break;
-            case 낙인.고양:
-                newPassive = new 고양(); 
-                break;
-            case 낙인.대죄:
-                newPassive = new 대죄();
-                break;
-            case 낙인.자애:
-                newPassive = new 자애();
-                break;
-            case 낙인.처형:
-                newPassive = new 처형();
-                break;
-            case 낙인.흡수:
-                newPassive = new 흡수();
-                break;
-            case 낙인.오빠:
-                newPassive = new 오빠();
-                break;
-            case 낙인.동생:
-                newPassive = new 동생();
-                break;
-            case 낙인.고문관:
-                newPassive = new 고문관();
-                break;
-            case 낙인.망령:
-                newPassive = new 망령();
-                break;
-        }
-
-        foreach(Passive passive in Stigma)
-            if(passive.GetType() == newPassive.GetType())
-            {
-                Debug.Log("이미 장착된 낙인입니다.");
-                return;
-            }
-
-        Stigma.Add(newPassive);
-        Debug.Log($"{Data.name}에 {newPassive.GetType()} 낙인이 장착되었습니다.");
     }
 }

--- a/Assets/Script/Unit/DeckUnit.cs
+++ b/Assets/Script/Unit/DeckUnit.cs
@@ -17,7 +17,7 @@ public class DeckUnit
 
     public void SetStigma()
     {
-        foreach (Passive stigma in Data.IngerenceStigma)
+        foreach (Passive stigma in Data.UniqueStigma)
             AddStigma(stigma);
 
         foreach (Passive stigma in Stigma)
@@ -39,19 +39,5 @@ public class DeckUnit
         }
 
         Stigma.Add(passive);
-    }
-
-    public Type RemoveRandomStigma()
-    {
-        if(Stigma.Count <= 0)
-        {
-            Debug.Log("삭제할 낙인이 없습니다.");
-            return null;
-        }
-
-        int num = UnityEngine.Random.Range(0, Stigma.Count);
-        Type removed = Stigma[num].GetType(); // 지워질 패시브의 정보
-        Stigma.RemoveAt(num);
-        return removed;
     }
 }

--- a/Assets/Script/Unit/DeckUnit.cs
+++ b/Assets/Script/Unit/DeckUnit.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 [Serializable]
@@ -17,6 +18,8 @@ public class DeckUnit
 
     public void SetStigma()
     {
+        Stigma = Stigma.Distinct().ToList();
+
         foreach (Passive stigma in Data.UniqueStigma)
             AddStigma(stigma);
 

--- a/Assets/Script/Unit/Passvie/Passive.cs
+++ b/Assets/Script/Unit/Passvie/Passive.cs
@@ -4,14 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
-
-public enum 낙인
-{
-    고양, 자애, 강림, // 소환 시
-    가학, 흡수, 처형, 대죄, // 공격 후
-    오빠, 동생, 고문관, 망령 // 특수 낙인
-}
-
 public class Passive : MonoBehaviour
 {
     [SerializeField] private string _name;

--- a/Assets/Script/Unit/Passvie/PassiveManager.cs
+++ b/Assets/Script/Unit/Passvie/PassiveManager.cs
@@ -8,7 +8,7 @@ public class PassiveManager
     public enum PassiveManageType
     {
         Entire,
-        Special,
+        Unique,
         Common,
     }
 
@@ -23,7 +23,7 @@ public class PassiveManager
     private void LoadPassiveList()
     {
         List<Passive> common = new List<Passive>();
-        List<Passive> special = new List<Passive>();
+        List<Passive> unique = new List<Passive>();
         List<Passive> entire = new List<Passive>();
 
         string path = "Assets/Resources/Prefabs/Passive";
@@ -39,7 +39,7 @@ public class PassiveManager
             Passive passive = go.GetComponent<Passive>();
 
             if (passive.IsSpecial)
-                special.Add(passive);
+                unique.Add(passive);
             else
                 common.Add(passive);
 
@@ -47,7 +47,7 @@ public class PassiveManager
         }
 
         PassiveDict.Add(PassiveManageType.Common, common);
-        PassiveDict.Add(PassiveManageType.Special, special);
+        PassiveDict.Add(PassiveManageType.Unique, unique);
         PassiveDict.Add(PassiveManageType.Entire, entire);
     }
 

--- a/Assets/Script/Unit/Passvie/PassiveManager.cs
+++ b/Assets/Script/Unit/Passvie/PassiveManager.cs
@@ -51,16 +51,9 @@ public class PassiveManager
         PassiveDict.Add(PassiveManageType.Entire, entire);
     }
 
-    public Passive GetRandomPassive(bool includeSpecial = false)
+    public Passive GetRandomPassive(PassiveManageType passiveType = PassiveManageType.Common)
     {
-        PassiveManageType type;
-
-        if (includeSpecial)
-            type = PassiveManageType.Entire;
-        else
-            type = PassiveManageType.Common;
-
-        int randNum = Random.Range(0, PassiveDict[type].Count);
-        return PassiveDict[type][randNum];
+        int randNum = Random.Range(0, PassiveDict[passiveType].Count);
+        return PassiveDict[passiveType][randNum];
     }
 }


### PR DESCRIPTION
## 📝 PR 설명
1. 낙인 Enum을 제거 했습니다.
2. Deck에서 낙인을 직접 설정할 때 중복을 제거하도록 변경했습니다.
3. 랜덤 낙인을 생성할 때 기존에는 일반 낙인 혹은 전체 낙인 중에만 선택 가능했는데, 이제는 고유 낙인도 가져올 수 있도록 수정했습니다.

5. 고유낙인(inherent stigma)의 오타를 고칠 겸 알아보기 힘들다는 의견을 받아 unique로 변경했습니다.
6. Special Stigma를 Unique로 용어를 통일했습니다.

## 🧪 테스트 방법
Deck Unit에 낙인을 중복으로 넣어도 Battle Scene에서 실행했을 때 중복이 제거되는 것을 확인했습니다.