### PR TITLE
턴 알림 표시 후 대기 시간 추가

### DIFF
--- a/Assets/Script/UI/Scene/UI_TurnNotify.cs
+++ b/Assets/Script/UI/Scene/UI_TurnNotify.cs
@@ -7,11 +7,12 @@ using UnityEngine.EventSystems;
 public class UI_TurnNotify : UI_Scene
 {
     const float fadeTime = 0.5f;
+    const float displayTime = 0.5f;
 
     public void SetPlayerTurnImage()
     {
         FadeIn();
-        Invoke("FadeOut", fadeTime);
+        Invoke("FadeOut", fadeTime + displayTime);
 
         GetComponent<Image>().sprite = GameManager.Resource.Load<Sprite>($"Arts/UI/Battle_UI/Text/PlayerTurnText");
     }
@@ -19,7 +20,7 @@ public class UI_TurnNotify : UI_Scene
     public void SetUnitTurnImage()
     {
         FadeIn();
-        Invoke("FadeOut", fadeTime);
+        Invoke("FadeOut", fadeTime + displayTime);
 
         GetComponent<Image>().sprite = GameManager.Resource.Load<Sprite>($"Arts/UI/Battle_UI/Text/UnitTurnText");
     }


### PR DESCRIPTION
## 📝 PR 설명
> 턴 알림이 페이드인해 표시한 후 0.5 대기하고 페이드아웃하도록 대기 시간 추가 추가

## 🧪 테스트 방법
> 로컬에서 실행