### PR TITLE
엘리트 전투 종료 시 엔딩 크레딧 올라오도록 변경

### DIFF
--- a/Assets/Script/Effect/VisualEffectManager.cs
+++ b/Assets/Script/Effect/VisualEffectManager.cs
@@ -80,7 +80,6 @@ public class VisualEffectManager : MonoBehaviour
 
     private void CreateEffect(AnimEffects effect)
     {
-        Debug.Log(root);
         GameObject go = GameManager.Resource.Instantiate($"Effect/{AnimEffectNames[effect]}", root.transform);
         RestoreEffect(effect, go);
     }

--- a/Assets/Script/Manager/BattleManager/BattleManager.cs
+++ b/Assets/Script/Manager/BattleManager/BattleManager.cs
@@ -394,7 +394,10 @@ public class BattleManager : MonoBehaviour
         Debug.Log("YOU WIN");
         Data.OnBattleOver();
         _phase.ChangePhase(new BattleOverPhase());
-        GameManager.UI.ShowScene<UI_BattleOver>().SetImage("win");
+        if(GameManager.Data.CurrentStageData.Level == 11)
+            GameManager.UI.ShowScene<UI_BattleOver>().SetImage("elite win");
+        else
+            GameManager.UI.ShowScene<UI_BattleOver>().SetImage("win");
     }
 
     private void BattleOverLose()


### PR DESCRIPTION
## 📝 PR 설명
> 이 PR에서 추가/수정하려는 내용, 이 PR이 필요한 이유, 이런 방식으로 구현한 이유, 기타 중요한 내용 등을 정리해 적어주세요.

- 엘리트 전투 종료 시 일반 전투 종료가 전달하던 정보 대신 엘리트 전투 종료의 정보를 건네주도록 변경

## 🧪 테스트 방법
> 이 PR이 목표한 바를 잘 달성하고 있는지 확인한 방법을 알려주세요.