### PR TITLE
아군 타락 시에도 낙인 선택지 뜨는 문제 수정

### DIFF
--- a/Assets/Resources/Prefabs/UI/Popup/UI_Conversation.prefab
+++ b/Assets/Resources/Prefabs/UI/Popup/UI_Conversation.prefab
@@ -115,6 +115,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 128b6b2fdda3b9f4289536f0903d7138, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _conversationText: {fileID: 1395442277994067936}
+  _nameText: {fileID: 2064151088479464520}
+  _nameObject: {fileID: 6791079070738463765}
 --- !u!1 &2734483727444442809
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Manager/BattleManager/BattleManager.cs
+++ b/Assets/Script/Manager/BattleManager/BattleManager.cs
@@ -312,9 +312,12 @@ public class BattleManager : MonoBehaviour
 
     public void StigmaSelectEvent(Corruption cor)
     {
-        List<Passive> stigmaList = new List<Passive>();
-         
-        GameManager.UI.ShowPopup<UI_StigmaSelectButtonPopup>().Init(cor.GetTargetUnit().DeckUnit, 2, cor.LoopExit);
+        BattleUnit targetUnit = cor.GetTargetUnit();
+
+        if (targetUnit.Team == Team.Enemy)
+            GameManager.UI.ShowPopup<UI_StigmaSelectButtonPopup>().Init(targetUnit.DeckUnit, 2, cor.LoopExit);
+        else
+            cor.LoopExit();
     }
 
     private void UnitDeadAction(BattleUnit _unit)

--- a/Assets/Script/UI/Popup/UI_Conversation.cs
+++ b/Assets/Script/UI/Popup/UI_Conversation.cs
@@ -41,6 +41,15 @@ public class UI_Conversation : UI_Popup
 
             co_typing = StartCoroutine(TypingEffect(script.script));
 
+            yield return new WaitUntil(() => (co_typing == null || GameManager.InputManager.Click));
+
+            if(co_typing != null)
+            {
+                StopCoroutine(co_typing);
+                co_typing = null;
+            }
+            _conversationText.text = script.script;
+
             yield return new WaitUntil(() => GameManager.InputManager.Click);
         }
 

--- a/Assets/Script/UI/Popup/UI_Conversation.cs
+++ b/Assets/Script/UI/Popup/UI_Conversation.cs
@@ -10,23 +10,13 @@ public class UI_Conversation : UI_Popup
     private Coroutine co_typing = null;
     private List<Script> scripts = new List<Script>();
 
-    enum Texts
-    {
-        ConversationText,
-        NameText,
-    }
-
-    enum Objects
-    {
-        Name,
-    }
+    [SerializeField] private Text _conversationText;
+    [SerializeField] private Text _nameText;
+    [SerializeField] private GameObject _nameObject;
 
     // autoStart = false면 따로 실행해줘야 함
     public void Init(List<Script> scripts, bool autoStart = true)
     {
-        Bind<Text>(typeof(Texts));
-        Bind<GameObject>(typeof(Objects));
-
         this.scripts = scripts;
 
         if (autoStart == false)
@@ -42,11 +32,11 @@ public class UI_Conversation : UI_Popup
         {
             // 이름 없으면 이름 창 꺼짐
             if (script.name == "")
-                GetObject((int)Objects.Name).SetActive(false);
+                _nameObject.SetActive(false);
             else
             {
-                GetObject((int)Objects.Name).SetActive(true);
-                GetText((int)Texts.NameText).text = script.name;
+                _nameObject.SetActive(true);
+                _nameText.text = script.name;
             }
 
             co_typing = StartCoroutine(TypingEffect(script.script));
@@ -59,7 +49,7 @@ public class UI_Conversation : UI_Popup
 
     private IEnumerator TypingEffect(string script)
     {
-        Text text = GetText((int)Texts.ConversationText);
+        Text text = _conversationText;
         text.text = "";
 
         foreach (char c in script.ToCharArray())


### PR DESCRIPTION
## 📝 PR 설명
적군 -> 아군 타락 시에만 낙인을 추가할 수 있어야 하는데, 양방향 둘 다 뜨던 문제를 해결했습니다.

## 🧪 테스트 방법
로컬 환경에서 실행해 수정된 걸 확인했습니다.